### PR TITLE
Fix application insights logging visualization

### DIFF
--- a/src/Alequeshow.Habitica.Webhooks/Program.cs
+++ b/src/Alequeshow.Habitica.Webhooks/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Refit;
 
 var builder = FunctionsApplication.CreateBuilder(args);
@@ -15,6 +16,18 @@ builder.ConfigureFunctionsWebApplication();
 builder.Services
     .AddApplicationInsightsTelemetryWorkerService()
     .ConfigureFunctionsApplicationInsights();
+
+builder.Services.Configure<LoggerFilterOptions>(options =>
+{
+    // Remove default Application Insights filter that might suppress logs
+    LoggerFilterRule? toRemove = options.Rules.FirstOrDefault(rule => rule.ProviderName
+        == "Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider");
+    
+    if (toRemove != null)
+    {
+        options.Rules.Remove(toRemove);
+    }
+});
 
 builder.Configuration
     .AddUserSecrets<Program>();

--- a/src/Alequeshow.Habitica.Webhooks/TaskEventWebHook.cs
+++ b/src/Alequeshow.Habitica.Webhooks/TaskEventWebHook.cs
@@ -17,7 +17,7 @@ namespace Alequeshow.Habitica.Webhooks
             {
                 var requestContent = await request.ToRequestContent();
 
-                logger.LogInformation("Received request: {RequestBody}", requestContent.ToString());
+                logger.LogInformation("TaskEventWebHook received request: {RequestBody}", requestContent.ToString());
 
                 if(requestContent.Body != null)
                 {

--- a/src/Alequeshow.Habitica.Webhooks/TimedEventFunction.cs
+++ b/src/Alequeshow.Habitica.Webhooks/TimedEventFunction.cs
@@ -13,7 +13,8 @@ namespace Alequeshow.Habitica.Webhooks
         [Function("TimedEventFunction")]
         public async Task Run([TimerTrigger("%TIMED_FUNCTION_CRON%")] TimerInfo timer)
         {
-            logger.LogInformation("Timed event function executed at: {Now}. Next execution: {next}", DateTime.UtcNow, timer.ScheduleStatus?.Next);
+            logger.LogInformation("TimedEventFunction started at {ExecutionTime} with next execution at {NextExecution}", 
+                DateTime.UtcNow, timer.ScheduleStatus?.Next);
             
             try
             {


### PR DESCRIPTION
This pull request introduces improvements to logging and configuration in the `Alequeshow.Habitica.Webhooks` project. The main changes focus on enhancing log visibility, especially for Application Insights, and making log messages more descriptive.

**Logging configuration and improvements:**

* Added configuration in `Program.cs` to remove the default Application Insights log filter, ensuring all logs are captured and not unintentionally suppressed.
* Updated log messages in `TaskEventWebHook.cs` and `TimedEventFunction.cs` to be more descriptive and consistent, improving traceability in logs.
* Added a missing `using Microsoft.Extensions.Logging;` statement in `Program.cs` to support logging configuration changes.